### PR TITLE
Adds keywords command to return Gambit production keywords

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Botkit = require('botkit');
 
 const controller = Botkit.slackbot();
@@ -23,12 +25,41 @@ controller.hears('eye', ['mention', 'ambient'], (bot, message) => {
 });
 
 controller.hears('keywords', ['mention', 'direct_message'], (bot, message) => {
-  let output = 'Campaigns running on Gambit production:\n';
+  console.log('keywords');
+  let output = {
+    username: 'Puppet Sloth',
+    text: 'Campaigns running on Gambit production:',
+    attachments: [],
+  };
+
+  const colors = [ 'FCD116', '23b7fb', '4e2b63' ];
+
   request.get(`${gambitBaseUri}campaigns`)
     .then((response) => {
-      response.body.data.forEach((campaign) => {
-        output = `${output} - ${campaign.title}\n`
-      })
+      response.body.data.forEach((campaign, index) => {
+        const keywords = campaign.keywords.map(entry => entry.keyword);
+
+        const attachment = {
+          color: `#${colors[index % 3]}`,
+          title: `${campaign.title} (ID ${campaign.id})`,
+          title_link: `https://dosomething.org/node/${campaign.id}`,
+          fields: [
+            {
+              title: 'Keywords',
+              value: keywords.join(', '),
+              short: true,
+            },
+            {
+              title: 'Status',
+              value: campaign.status,
+              short: true,
+            },
+          ],
+        }
+        output.attachments.push(attachment);
+      });
+
       bot.reply(message, output);
     })
+    .catch(err => console.log(err));
 });

--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
-var Botkit = require('botkit');
+const Botkit = require('botkit');
 
 const controller = Botkit.slackbot();
 const bot = controller.spawn({
   token: process.env.SLACK_API_TOKEN,
 });
+
+const request = require('superagent');
+const gambitBaseUri = 'https://ds-mdata-responder.herokuapp.com/v1/'
 
 bot.startRTM((err, bot, payload) => {
   if (err) {
@@ -11,10 +14,21 @@ bot.startRTM((err, bot, payload) => {
   }
 });
 
-controller.hears('puppet', ['mention', 'ambient'], (bot,message) => {
+controller.hears('puppet', ['mention', 'ambient'], (bot, message) => {
   bot.reply(message, 'Puppet!');
 });
 
 controller.hears('eye', ['mention', 'ambient'], (bot, message) => {
   bot.reply(message, 'Somebody, please... fix my eye.');
+});
+
+controller.hears('keywords', ['mention', 'direct_message'], (bot, message) => {
+  let output = 'Campaigns running on Gambit production:\n';
+  request.get(`${gambitBaseUri}campaigns`)
+    .then((response) => {
+      response.body.data.forEach((campaign) => {
+        output = `${output} - ${campaign.title}\n`
+      })
+      bot.reply(message, output);
+    })
 });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "botkit": "^0.2.2"
+    "botkit": "^0.2.2",
+    "superagent": "^3.5.0"
   }
 }


### PR DESCRIPTION
* Adds `superagent` to GET Gambit `/v1/campaigns`
* Returns Campaign title, ID, link, keywords, and status as `attachments` in a Slack command if slothbot is sent a `keywords` command