### PR TITLE
Thor support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,2 +1,13 @@
 ---
   extends: "@dosomething/eslint-config"
+  parserOptions:
+    # Node requires 'use strict' to use built-in ES6 compatibility.
+    # Use script source type, so lint doesn't throw error:
+    # 'use strict' is unnecessary inside of modules.
+    sourceType: "script"
+  rules:
+    # We don't use babel here, so require 'use strict'.
+    # See https://git.io/vr6I0.
+    strict:
+      - 2
+      - "global"

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 const Promise = require('bluebird');
 const Botkit = require('botkit');
-const request = require('superagent');
 const helpers = require('./lib/helpers');
 
 const controller = Botkit.slackbot();
@@ -14,61 +13,14 @@ slothbot.startRTM((err) => {
   }
 });
 
-/**
- * Fetches Gambit campaigns on production, or for given environment.
- */
-function fetchCampaigns(environmentName) {
-  const output = {
-    username: 'Puppet Sloth',
-    text: `Gambit Campaigns running on *${environmentName.toUpperCase()}*:`,
-    mrkdwn: true,
-    attachments: [],
-  };
-
-  const colors = ['FCD116', '23b7fb', '4e2b63'];
-
-  return new Promise((resolve, reject) => {
-    const gambitCampaignsUri = `${helpers.gambitApiBaseUri(environmentName)}campaigns`;
-
-    return request.get(gambitCampaignsUri)
-      .then((response) => {
-        response.body.data.forEach((campaign, index) => {
-          const campaignUri = `${helpers.phoenixBaseUri(environmentName)}node/${campaign.id}`;
-          const keywords = campaign.keywords.map(entry => entry.keyword);
-
-          output.attachments.push({
-            color: `#${colors[index % 3]}`,
-            title: `${campaign.title} (ID ${campaign.id})`,
-            title_link: campaignUri,
-            fields: [
-              {
-                title: 'Keywords',
-                value: keywords.join(', '),
-                short: true,
-              },
-              {
-                title: 'Status',
-                value: campaign.status,
-                short: true,
-              },
-            ],
-          });
-        });
-
-        return resolve(output);
-      })
-    .catch(err => reject(err));
-  });
-}
-
 controller.hears('keywords', ['mention', 'direct_message'], (bot, message) => {
-  fetchCampaigns('production')
+  helpers.fetchCampaigns('production')
     .then(response => bot.reply(message, response))
     .catch(err => bot.reply(message, err.message));
 });
 
 controller.hears('thor', ['mention', 'direct_message'], (bot, message) => {
-  fetchCampaigns('thor')
+  helpers.fetchCampaigns('thor')
     .then(response => bot.reply(message, response))
     .catch(err => bot.reply(message, err.message));
 });

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+'use strict';
+
+const Promise = require('bluebird');
 const Botkit = require('botkit');
 const request = require('superagent');
 
@@ -10,48 +13,70 @@ slothbot.startRTM((err) => {
   }
 });
 
-controller.hears('puppet', ['mention', 'ambient'], (bot, message) => {
-  bot.reply(message, 'Puppet!');
-});
+/**
+ * Returns Gambit URI for production, or Thor if set as environmentName.
+ */
+function gambitUri(environmentName) {
+  let subdomain = 'ds-mdata-responder';
+  if (environmentName === 'thor') {
+    subdomain = `${subdomain}-staging`;
+  }
+  return `https://${subdomain}.herokuapp.com/v1/`;
+}
 
-controller.hears('eye', ['mention', 'ambient'], (bot, message) => {
-  bot.reply(message, 'Somebody, please... fix my eye.');
-});
-
-controller.hears('keywords', ['mention', 'direct_message'], (bot, message) => {
+/**
+ * Fetches Gambit campaigns on production, or for given environment.
+ */
+function fetchCampaigns(environmentName) {
   const output = {
     username: 'Puppet Sloth',
-    text: 'Campaigns running on Gambit production:',
+    text: `Gambit Campaigns running on *${environmentName.toUpperCase()}*:`,
+    mrkdwn: true,
     attachments: [],
   };
 
   const colors = ['FCD116', '23b7fb', '4e2b63'];
-  const gambitBaseUri = 'https://ds-mdata-responder.herokuapp.com/v1/';
 
-  request.get(`${gambitBaseUri}campaigns`)
-    .then((response) => {
-      response.body.data.forEach((campaign, index) => {
-        const keywords = campaign.keywords.map(entry => entry.keyword);
-        output.attachments.push({
-          color: `#${colors[index % 3]}`,
-          title: `${campaign.title} (ID ${campaign.id})`,
-          title_link: `https://dosomething.org/node/${campaign.id}`,
-          fields: [
-            {
-              title: 'Keywords',
-              value: keywords.join(', '),
-              short: true,
-            },
-            {
-              title: 'Status',
-              value: campaign.status,
-              short: true,
-            },
-          ],
+  return new Promise((resolve, reject) => {
+    const uri = `${gambitUri(environmentName)}campaigns`;
+
+    return request.get(uri)
+      .then((response) => {
+        response.body.data.forEach((campaign, index) => {
+          const keywords = campaign.keywords.map(entry => entry.keyword);
+          output.attachments.push({
+            color: `#${colors[index % 3]}`,
+            title: `${campaign.title} (ID ${campaign.id})`,
+            title_link: `https://dosomething.org/node/${campaign.id}`,
+            fields: [
+              {
+                title: 'Keywords',
+                value: keywords.join(', '),
+                short: true,
+              },
+              {
+                title: 'Status',
+                value: campaign.status,
+                short: true,
+              },
+            ],
+          });
         });
-      });
 
-      bot.reply(message, output);
-    })
+        return resolve(output);
+      })
+    .catch(err => reject(err));
+  });
+}
+
+controller.hears('keywords', ['mention', 'direct_message'], (bot, message) => {
+  fetchCampaigns('production')
+    .then(response => bot.reply(message, response))
+    .catch(err => bot.reply(message, err.message));
+});
+
+controller.hears('thor', ['mention', 'direct_message'], (bot, message) => {
+  fetchCampaigns('thor')
+    .then(response => bot.reply(message, response))
     .catch(err => bot.reply(message, err.message));
 });

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Promise = require('bluebird');
 const Botkit = require('botkit');
 const helpers = require('./lib/helpers');
 
@@ -14,13 +13,17 @@ slothbot.startRTM((err) => {
 });
 
 controller.hears('keywords', ['mention', 'direct_message'], (bot, message) => {
-  helpers.fetchCampaigns('production')
+  bot.reply(message, 'Finding all Gambit campaigns running on production...');
+
+  return helpers.fetchCampaigns('production')
     .then(response => bot.reply(message, response))
     .catch(err => bot.reply(message, err.message));
 });
 
 controller.hears('thor', ['mention', 'direct_message'], (bot, message) => {
-  helpers.fetchCampaigns('thor')
+  bot.reply(message, 'Finding all Gambit campaigns running on Thor...');
+
+  return helpers.fetchCampaigns('thor')
     .then(response => bot.reply(message, response))
     .catch(err => bot.reply(message, err.message));
 });

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const request = require('superagent');
+
 /**
  * Returns Gambit URI for production, or Thor if set as environmentName.
  */
@@ -22,4 +24,51 @@ module.exports.phoenixBaseUri = function (environmentName) {
   }
 
   return `https://${subdomain}dosomething.org/`;
+};
+
+/**
+ * Fetches Gambit campaigns on production, or for given environment.
+ */
+module.exports.fetchCampaigns = function (environmentName) {
+  const output = {
+    username: 'Puppet Sloth',
+    text: `Gambit Campaigns running on *${environmentName.toUpperCase()}*:`,
+    mrkdwn: true,
+    attachments: [],
+  };
+
+  const colors = ['FCD116', '23b7fb', '4e2b63'];
+
+  return new Promise((resolve, reject) => {
+    const gambitCampaignsUri = `${this.gambitApiBaseUri(environmentName)}campaigns`;
+
+    return request.get(gambitCampaignsUri)
+      .then((response) => {
+        response.body.data.forEach((campaign, index) => {
+          const campaignUri = `${this.phoenixBaseUri(environmentName)}node/${campaign.id}`;
+          const keywords = campaign.keywords.map(entry => entry.keyword);
+
+          output.attachments.push({
+            color: `#${colors[index % 3]}`,
+            title: `${campaign.title} (ID ${campaign.id})`,
+            title_link: campaignUri,
+            fields: [
+              {
+                title: 'Keywords',
+                value: keywords.join(', '),
+                short: true,
+              },
+              {
+                title: 'Status',
+                value: campaign.status,
+                short: true,
+              },
+            ],
+          });
+        });
+
+        return resolve(output);
+      })
+    .catch(err => reject(err));
+  });
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,4 +1,25 @@
-# lib/slothbot.js
+'use strict';
 
-var Bot = require('slackbots');
+/**
+ * Returns Gambit URI for production, or Thor if set as environmentName.
+ */
+module.exports.gambitApiBaseUri = function (environmentName) {
+  let subdomain = 'ds-mdata-responder';
+  if (environmentName === 'thor') {
+    subdomain = `${subdomain}-staging`;
+  }
 
+  return `https://${subdomain}.herokuapp.com/v1/`;
+};
+
+/**
+ * Returns Phoenix URI for production, or Thor if set as environmentName.
+ */
+module.exports.phoenixBaseUri = function (environmentName) {
+  let subdomain = '';
+  if (environmentName === 'thor') {
+    subdomain = 'thor.';
+  }
+
+  return `https://${subdomain}dosomething.org/`;
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run lint",
     "start": "node index",
-    "lint": "eslint --ext=.js index.js"
+    "lint": "eslint --ext=.js index.js lib"
   },
   "author": "DoSomething.org",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "node": ">=6.10.x"
   },
   "dependencies": {
+    "bluebird": "^3.5.0",
     "botkit": "^0.2.2",
     "superagent": "^3.5.0"
   },


### PR DESCRIPTION
- Moves `fetchCampaigns` into `lib/helpers`, along with `gambitApiBaseUri` and `phoenixApi` helper functions
- Supports listing Thor keywords with a `thor` command and production keywords with `keywords` command

<img width="616" alt="screen shot 2017-03-13 at 7 41 33 pm" src="https://cloud.githubusercontent.com/assets/1236811/23879757/960a7524-0825-11e7-895e-e38f45656407.png">