### PR TITLE
View Messages button

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ controller.hears('thor', ['direct_mention', 'direct_message'], (bot, message) =>
 
 controller.on('interactive_message_callback', (bot, message) => {
   logger.info(`Received interactive_message_callback:${message.callback_id}`);
+  // Our callback_id is defined as environmentName_campaignId, e.g. 'thor_7483'.
   const data = message.callback_id.split('_');
 
   return helpers.fetchRenderedCampaignMessages(data[1], data[0])

--- a/index.js
+++ b/index.js
@@ -41,8 +41,11 @@ controller.hears('thor', ['direct_mention', 'direct_message'], (bot, message) =>
 
 controller.on('interactive_message_callback', (bot, message) => {
   logger.info(`Received interactive_message_callback:${message.callback_id}`);
+  const data = message.callback_id.split('_');
 
-  slothbot.reply(message, `Hi ${message.callback_id}`);
+  return helpers.fetchRenderedCampaignMessages(data[1], data[0])
+    .then(response => slothbot.reply(message, response))
+    .catch(err => slothbot.reply(message, err.message));
 });
 
 const port = process.env.PORT || 5000;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const Botkit = require('botkit');
 const helpers = require('./lib/helpers');
+const logger = require('winston');
 
 const controller = Botkit.slackbot({
   clientId: process.env.SLACK_CLIENT_ID,
@@ -18,9 +19,8 @@ slothbot.startRTM((err, bot, payload) => {
   // Save team to get Interactive Messages working.
   // @see https://github.com/howdyai/botkit/issues/108.
   controller.saveTeam(payload.team, () => {
-    console.log('Saved team');
+    logger.info(`Saved team id:${payload.team.id}`);
   });
-
 });
 
 controller.hears('keywords', ['direct_mention', 'direct_message'], (bot, message) => {
@@ -40,7 +40,8 @@ controller.hears('thor', ['direct_mention', 'direct_message'], (bot, message) =>
 });
 
 controller.on('interactive_message_callback', (bot, message) => {
-  console.log(message.callback_id);
+  logger.info(`Received interactive_message_callback:${message.callback_id}`);
+
   slothbot.reply(message, `Hi ${message.callback_id}`);
 });
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -50,9 +50,18 @@ module.exports.fetchCampaigns = function (environmentName) {
           const keywords = campaign.keywords.map(entry => entry.keyword);
 
           output.attachments.push({
+            callback_id: `${environmentName}_${campaign.id}`,
             color: `#${colors[index % 3]}`,
             title: `${campaign.title} (id: ${campaign.id})`,
             title_link: campaignUri,
+            actions: [
+              {
+                name: 'action',
+                text: 'View messages',
+                type: 'button',
+                value: 'messages',
+              },
+            ],
             fields: [
               {
                 title: 'Keywords',

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,14 @@
 'use strict';
 
 const request = require('superagent');
+const logger = require('winston');
+
+const botResponse = {
+  username: 'Puppet Sloth',
+  icon_url: 'https://pbs.twimg.com/profile_images/344513261577739462/0ffdff5acd5ff3bcd34c0cd10baf2a14.png',
+  mrkdwn: true,
+};
+const colors = ['FCD116', '23b7fb', '4e2b63'];
 
 /**
  * Returns Gambit URI for production, or Thor if set as environmentName.
@@ -30,26 +38,21 @@ module.exports.phoenixBaseUri = function (environmentName) {
  * Fetches Gambit campaigns on production, or for given environment.
  */
 module.exports.fetchCampaigns = function (environmentName) {
-  const output = {
-    username: 'Puppet Sloth',
-    icon_url: 'https://pbs.twimg.com/profile_images/344513261577739462/0ffdff5acd5ff3bcd34c0cd10baf2a14.png',
-    text: `Gambit Campaigns running on *${environmentName.toUpperCase()}*:`,
-    mrkdwn: true,
-    attachments: [],
-  };
-
-  const colors = ['FCD116', '23b7fb', '4e2b63'];
+  logger.debug(`fetchCampaigns:${environmentName}`);
 
   return new Promise((resolve, reject) => {
     const gambitCampaignsUri = `${this.gambitApiBaseUri(environmentName)}campaigns`;
 
     return request.get(gambitCampaignsUri)
       .then((response) => {
+        botResponse.text = `Gambit Campaigns running on *${environmentName.toUpperCase()}*:`;
+        botResponse.attachments = [];
+
         response.body.data.forEach((campaign, index) => {
           const campaignUri = `${this.phoenixBaseUri(environmentName)}node/${campaign.id}`;
           const keywords = campaign.keywords.map(entry => entry.keyword);
 
-          output.attachments.push({
+          botResponse.attachments.push({
             callback_id: `${environmentName}_${campaign.id}`,
             color: `#${colors[index % 3]}`,
             title: `${campaign.title} (id: ${campaign.id})`,
@@ -77,8 +80,26 @@ module.exports.fetchCampaigns = function (environmentName) {
           });
         });
 
-        return resolve(output);
+        return resolve(botResponse);
       })
     .catch(err => reject(err));
+  });
+};
+
+module.exports.fetchRenderedCampaignMessages = function (campaignId, environmentName) {
+  logger.info(`fetchRenderedCampaignMessages:${campaignId} ${environmentName}`);
+
+  return new Promise((resolve, reject) => {
+    const gambitCampaignUri = `${this.gambitApiBaseUri(environmentName)}campaigns/${campaignId}`;
+
+    return request.get(gambitCampaignUri)
+      .then((response) => {
+        const campaign = response.body.data;
+        botResponse.text = `Messages for *${campaign.title}* on ${environmentName}:`;
+        botResponse.attachments = [];
+
+        return resolve(botResponse);
+      })
+      .catch(err => reject(err));
   });
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,11 +3,6 @@
 const request = require('superagent');
 const logger = require('winston');
 
-const botResponse = {
-  username: 'Puppet Sloth',
-  icon_url: 'https://pbs.twimg.com/profile_images/344513261577739462/0ffdff5acd5ff3bcd34c0cd10baf2a14.png',
-  mrkdwn: true,
-};
 const colors = ['FCD116', '23b7fb', '4e2b63'];
 
 /**
@@ -45,8 +40,11 @@ module.exports.fetchCampaigns = function (environmentName) {
 
     return request.get(gambitCampaignsUri)
       .then((response) => {
-        botResponse.text = `Gambit Campaigns running on *${environmentName.toUpperCase()}*:`;
-        botResponse.attachments = [];
+        const botResponse = {
+          mrkdwn: true,
+          text: `Gambit Campaigns running on *${environmentName.toUpperCase()}*:`,
+          attachments: [],
+        };
 
         response.body.data.forEach((campaign, index) => {
           const campaignUri = `${this.phoenixBaseUri(environmentName)}node/${campaign.id}`;
@@ -95,8 +93,10 @@ module.exports.fetchRenderedCampaignMessages = function (campaignId, environment
     return request.get(gambitCampaignUri)
       .then((response) => {
         const campaign = response.body.data;
-        botResponse.text = `Messages for *${campaign.title}* on ${environmentName}:`;
-        botResponse.attachments = [];
+        const botResponse = {
+          text: `Messages for *${campaign.title}* on ${environmentName}:`,
+          attachments: [],
+        };
 
         return resolve(botResponse);
       })

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "botkit": "^0.2.2",
-    "superagent": "^3.5.0"
+    "superagent": "^3.5.0",
+    "winston": "^2.3.1"
   },
   "devDependencies": {
     "@dosomething/eslint-config": "^2.0.0",


### PR DESCRIPTION
* Adds a "View Messages" action to the Campaign list, and starts on fetching a Campaign's rendered messages upon clicking it.
* Implements Slothbot as a Slack app instead of a custom Slackbot to support interactive messages
* Adds stub function to view a Campaign's rendered messages, blocked by https://github.com/DoSomething/gambit/issues/798