### PR TITLE
View rendered Campaign messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@ Slothbot is an internal DoSomething.org Slack app used for tasks like returning 
 
 The Slothbot is named in honor of the DoSomething Puppet Sloth, who would like to remind you from the grave that he once [interviewed Tyler Oakley](https://youtu.be/wetvnbDB4wg).
 
-Slothbot currently supports 2 commands:
+Commands for mentioning `@slothbot`:
+
+* `help` -- introduction, list direct messages commands
+
+Commands for direct messages to `@slothbot`:
 
 * `keywords` -- returns all production Gambit campaigns and keywords 
 * `thor` -- returns all Thor Gambit campaigns and keywords

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ slothbot.startRTM((err, bot, payload) => {
   });
 });
 
-controller.hears('keywords', ['direct_mention', 'direct_message'], (bot, message) => {
+controller.hears('keywords', ['direct_message'], (bot, message) => {
   bot.reply(message, 'Finding all Gambit Campaigns running on production...');
 
   return helpers.fetchCampaigns('production')
@@ -31,7 +31,7 @@ controller.hears('keywords', ['direct_mention', 'direct_message'], (bot, message
     .catch(err => slothbot.reply(message, err.message));
 });
 
-controller.hears('thor', ['direct_mention', 'direct_message'], (bot, message) => {
+controller.hears('thor', ['direct_message'], (bot, message) => {
   bot.reply(message, 'Finding all Gambit Campaigns running on Thor...');
 
   return helpers.fetchCampaigns('thor')

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ slothbot.startRTM((err, bot, payload) => {
 });
 
 controller.hears('keywords', ['direct_mention', 'direct_message'], (bot, message) => {
-  bot.reply(message, 'Finding all Gambit campaigns running on production...');
+  bot.reply(message, 'Finding all Gambit Campaigns running on production...');
 
   return helpers.fetchCampaigns('production')
     .then(response => slothbot.reply(message, response))
@@ -32,7 +32,7 @@ controller.hears('keywords', ['direct_mention', 'direct_message'], (bot, message
 });
 
 controller.hears('thor', ['direct_mention', 'direct_message'], (bot, message) => {
-  bot.reply(message, 'Finding all Gambit campaigns running on Thor...');
+  bot.reply(message, 'Finding all Gambit Campaigns running on Thor...');
 
   return helpers.fetchCampaigns('thor')
     .then(response => slothbot.reply(message, response))
@@ -43,8 +43,12 @@ controller.on('interactive_message_callback', (bot, message) => {
   logger.info(`Received interactive_message_callback:${message.callback_id}`);
   // Our callback_id is defined as environmentName_campaignId, e.g. 'thor_7483'.
   const data = message.callback_id.split('_');
+  const campaignId = data[1];
+  const environmentName = data[0];
+  const findingMsg = `Finding all messages for Campaign ${campaignId} on ${environmentName}...`;
+  slothbot.reply(message, findingMsg);
 
-  return helpers.fetchRenderedCampaignMessages(data[1], data[0])
+  return helpers.fetchRenderedCampaignMessages(campaignId, environmentName)
     .then(response => slothbot.reply(message, response))
     .catch(err => slothbot.reply(message, err.message));
 });

--- a/index.js
+++ b/index.js
@@ -23,6 +23,13 @@ slothbot.startRTM((err, bot, payload) => {
   });
 });
 
+controller.hears('help', ['direct_mention', 'direct_message'], (bot, message) => {
+  const helpMsg = 'Hey, it\'s me, Puppet Sloth. I\'ve been resurrected as a bot who knows what ' +
+    'campaigns currently have SMS keywords.\n\nSend me a direct message that says *keywords* to ' +
+    'see what keywords are live. You can also send a DM with *thor* to view our test keywords.';
+  bot.reply(message, helpMsg);
+});
+
 controller.hears('keywords', ['direct_message'], (bot, message) => {
   bot.reply(message, 'Finding all Gambit Campaigns running on production...');
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -136,7 +136,7 @@ module.exports.fetchRenderedCampaignMessages = function (campaignId, environment
           attachments: [],
         };
         if (!campaign.messages) {
-          botResponse.text = `${botResponse.text} Error: response.body.messages undefined`;
+          botResponse.text = `${botResponse.text}\n\n*Error:* \`response.body.messages\` undefined`;
           return resolve(botResponse);
         }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,6 +6,15 @@ const logger = require('winston');
 const doSomethingIconUri = 'https://cdn-images-1.medium.com/fit/c/200/200/0*YoWgEvVaSo21Jygb.jpeg';
 
 /**
+ * Returns given campaign's title appended with its campaign id.
+ * @param {Object} campaign
+ * @return {string}
+ */
+function campaignTitleWithId(campaign) {
+  return `${campaign.title} (id: ${campaign.id})`;
+}
+
+/**
  * Returns hex string to render a list element based on given index.
  * @param {number} index - The index number to return a color for.
  * @return {string}
@@ -72,7 +81,7 @@ module.exports.fetchCampaigns = function (environmentName) {
           botResponse.attachments.push({
             callback_id: `${environmentName}_${campaign.id}`,
             color: hexForIndex(index),
-            title: `${campaign.title} (id: ${campaign.id})`,
+            title: campaignTitleWithId(campaign),
             title_link: campaignUri,
             actions: [
               {
@@ -120,8 +129,10 @@ module.exports.fetchRenderedCampaignMessages = function (campaignId, environment
     return request.get(gambitCampaignUri)
       .then((response) => {
         const campaign = response.body.data;
+        let text = `Here's *${campaignTitleWithId(campaign)}* on ${environmentName}.`;
+        text = `${text}\n\nYou can view the raw values set here, as JSON: ${gambitCampaignUri}`;
         const botResponse = {
-          text: `Messages for *${campaign.title}* on ${environmentName}:`,
+          text,
           attachments: [],
         };
         if (!campaign.messages) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,8 +3,18 @@
 const request = require('superagent');
 const logger = require('winston');
 
-const colors = ['FCD116', '23b7fb', '4e2b63'];
 const doSomethingIconUri = 'https://cdn-images-1.medium.com/fit/c/200/200/0*YoWgEvVaSo21Jygb.jpeg';
+
+/**
+ * Returns hex string to render a list element based on given index.
+ * @param {number} index - The index number to return a color for.
+ * @return {string}
+ */
+function hexForIndex(index) {
+  const colors = ['FCD116', '23b7fb', '4e2b63'];
+
+  return `#${colors[index % colors.length]}`;
+}
 
 /**
  * Returns Gambit URI for production, or Thor if set as environmentName.
@@ -53,7 +63,7 @@ module.exports.fetchCampaigns = function (environmentName) {
 
           botResponse.attachments.push({
             callback_id: `${environmentName}_${campaign.id}`,
-            color: `#${colors[index % 3]}`,
+            color: hexForIndex(index),
             title: `${campaign.title} (id: ${campaign.id})`,
             title_link: campaignUri,
             actions: [
@@ -106,7 +116,7 @@ module.exports.fetchRenderedCampaignMessages = function (campaignId, environment
         const fieldNames = Object.keys(campaign.messages);
         fieldNames.forEach((fieldName, index) => {
           const attachment = {
-            color: `#${colors[index % 3]}`,
+            color: hexForIndex(index),
           };
           attachment.title = fieldName;
           if (campaign.messages[fieldName].override === true) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -130,7 +130,7 @@ module.exports.fetchRenderedCampaignMessages = function (campaignId, environment
       .then((response) => {
         const campaign = response.body.data;
         let text = `Here's *${campaignTitleWithId(campaign)}* on ${environmentName}.`;
-        text = `${text}\n\nYou can view the raw values set here, as JSON: ${gambitCampaignUri}`;
+        text = `${text}\n\nYou can view the raw copy here, as JSON: ${gambitCampaignUri}`;
         const botResponse = {
           text,
           attachments: [],

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,6 +4,7 @@ const request = require('superagent');
 const logger = require('winston');
 
 const colors = ['FCD116', '23b7fb', '4e2b63'];
+const doSomethingIconUri = 'https://cdn-images-1.medium.com/fit/c/200/200/0*YoWgEvVaSo21Jygb.jpeg';
 
 /**
  * Returns Gambit URI for production, or Thor if set as environmentName.
@@ -97,6 +98,28 @@ module.exports.fetchRenderedCampaignMessages = function (campaignId, environment
           text: `Messages for *${campaign.title}* on ${environmentName}:`,
           attachments: [],
         };
+        if (!campaign.messages) {
+          botResponse.text = `${botResponse.text} Error: response.body.messages undefined`;
+          return resolve(botResponse);
+        }
+
+        const fieldNames = Object.keys(campaign.messages);
+        fieldNames.forEach((fieldName, index) => {
+          const attachment = {
+            color: `#${colors[index % 3]}`,
+          };
+          attachment.title = fieldName;
+          if (campaign.messages[fieldName].override === true) {
+            attachment.title = `${attachment.title}**`;
+            attachment.footer = `**Overridden in Contentful on Campaign ${campaign.id}`;
+            attachment.footer_icon = doSomethingIconUri;
+          }
+          attachment.text = campaign.messages[fieldName].rendered;
+          if (!attachment.text) {
+            attachment.text = 'N/A';
+          }
+          botResponse.attachments.push(attachment);
+        });
 
         return resolve(botResponse);
       })

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -17,37 +17,45 @@ function hexForIndex(index) {
 }
 
 /**
- * Returns Gambit URI for production, or Thor if set as environmentName.
+ * Returns Gambit URI for production, or Thor if passed as environmentName.
+ * @param {string} environmentName - Pass 'thor' to return Thor URI, else returns prod URI.
+ * @return {string}
  */
-module.exports.gambitApiBaseUri = function (environmentName) {
+function gambitApiBaseUri(environmentName) {
   let subdomain = 'ds-mdata-responder';
   if (environmentName === 'thor') {
     subdomain = `${subdomain}-staging`;
   }
 
   return `https://${subdomain}.herokuapp.com/v1/`;
-};
+}
 
 /**
  * Returns Phoenix URI for production, or Thor if set as environmentName.
+ * @param {string} environmentName - Pass 'thor' to return Thor URI, else returns prod URI.
+ * @return {string}
  */
-module.exports.phoenixBaseUri = function (environmentName) {
+function phoenixBaseUri(environmentName) {
   let subdomain = '';
   if (environmentName === 'thor') {
     subdomain = 'thor.';
   }
 
   return `https://${subdomain}dosomething.org/`;
-};
+}
 
 /**
- * Fetches Gambit campaigns on production, or for given environment.
+ * Fetches Gambit campaigns for the given environmentName and renders them as attachments of an
+ * outgoing Slack message.
+ *
+ * @param {string} environmentName - Pass 'thor' to return Thor URI, else returns prod URI.
+ * @return {Promise}
  */
 module.exports.fetchCampaigns = function (environmentName) {
   logger.debug(`fetchCampaigns:${environmentName}`);
 
   return new Promise((resolve, reject) => {
-    const gambitCampaignsUri = `${this.gambitApiBaseUri(environmentName)}campaigns`;
+    const gambitCampaignsUri = `${gambitApiBaseUri(environmentName)}campaigns`;
 
     return request.get(gambitCampaignsUri)
       .then((response) => {
@@ -58,7 +66,7 @@ module.exports.fetchCampaigns = function (environmentName) {
         };
 
         response.body.data.forEach((campaign, index) => {
-          const campaignUri = `${this.phoenixBaseUri(environmentName)}node/${campaign.id}`;
+          const campaignUri = `${phoenixBaseUri(environmentName)}node/${campaign.id}`;
           const keywords = campaign.keywords.map(entry => entry.keyword);
 
           botResponse.attachments.push({
@@ -95,11 +103,19 @@ module.exports.fetchCampaigns = function (environmentName) {
   });
 };
 
+/**
+ * Fetches rendered Gambit campaign messages for the given campaignId and environmentName and
+ * renders them as attachments of an outgoing Slack message.
+ *
+ * @param {number} campaignId - The numeric Phoenix Campaign ID.
+ * @param {string} environmentName - Pass 'thor' to return Thor URI, else returns prod URI.
+ * @return {Promise}
+ */
 module.exports.fetchRenderedCampaignMessages = function (campaignId, environmentName) {
   logger.info(`fetchRenderedCampaignMessages:${campaignId} ${environmentName}`);
 
   return new Promise((resolve, reject) => {
-    const gambitCampaignUri = `${this.gambitApiBaseUri(environmentName)}campaigns/${campaignId}`;
+    const gambitCampaignUri = `${gambitApiBaseUri(environmentName)}campaigns/${campaignId}`;
 
     return request.get(gambitCampaignUri)
       .then((response) => {


### PR DESCRIPTION
* Picks up where #5 left off, by listing all rendered Campaign messages as attachments when a user clicks a "View Messages" interactive button, now that https://github.com/DoSomething/gambit/pull/820 has been merged.

* Adds a `help` command to list basic instructions

* Only listen for `keywords` and `thor` in direct messages to avoid flooding Slack with Campaign and Message attachment lists.

<img width="802" alt="screen shot 2017-03-17 at 10 24 13 am" src="https://cloud.githubusercontent.com/assets/1236811/24056216/1d3a443e-0b00-11e7-8c0b-3ffd03675d13.png">