### PR TITLE
Adds contentfulUri link

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -131,6 +131,7 @@ module.exports.fetchRenderedCampaignMessages = function (campaignId, environment
         const campaign = response.body.data;
         let text = `Here's *${campaignTitleWithId(campaign)}* on ${environmentName}.`;
         text = `${text}\n\nYou can view the raw copy here, as JSON: ${gambitCampaignUri}`;
+        text = `${text}\n\nEdit overrides: ${campaign.contentfulUri}`;
         const botResponse = {
           text,
           attachments: [],


### PR DESCRIPTION
Displays Contentful URL exposed in https://github.com/DoSomething/gambit/pull/822 to manage Campaign overrides.
<img width="642" alt="screen shot 2017-03-17 at 12 45 53 pm" src="https://cloud.githubusercontent.com/assets/1236811/24062894/91d139e6-0b1a-11e7-8ff5-b94e21a23138.png">
