### PR TITLE
Contentful Listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,20 +38,13 @@ client.getEntries({ content_type: 'listener' })
   .then((response) => {
     response.items.forEach((listener) => {
       controller.hears(listener.fields.keywords, listener.fields.events, (bot, message) => {
-        const responseMessages = listener.fields.responseMessages.split('|');
-        const replyMessage = responseMessages[Math.floor(Math.random() * responseMessages.length)];
+        const replyMessages = listener.fields.replyMessages.split('|');
+        const replyMessage = replyMessages[Math.floor(Math.random() * replyMessages.length)];
         bot.reply(message, replyMessage);
       });
     });
   });
 
-
-controller.hears('help', ['direct_mention', 'direct_message'], (bot, message) => {
-  const helpMsg = 'Hey, it\'s me, Puppet Sloth. I\'ve been resurrected as a bot who knows what ' +
-    'campaigns currently have SMS keywords.\n\nSend me a direct message that says *keywords* to ' +
-    'see what keywords are live. You can also send a DM with *thor* to view our test keywords.';
-  bot.reply(message, helpMsg);
-});
 
 controller.hears('keywords', ['direct_message'], (bot, message) => {
   bot.reply(message, 'Finding all Gambit Campaigns running on production...');

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Botkit = require('botkit');
+const contentful = require('contentful');
 const helpers = require('./lib/helpers');
 const logger = require('winston');
 
@@ -22,6 +23,28 @@ slothbot.startRTM((err, bot, payload) => {
     logger.info(`Saved team id:${payload.team.id}`);
   });
 });
+
+let client;
+try {
+  client = contentful.createClient({
+    space: process.env.CONTENTFUL_SPACE_ID,
+    accessToken: process.env.CONTENTFUL_ACCESS_TOKEN,
+  });
+} catch (err) {
+  logger.error(`contentful error:${err.message}`);
+}
+
+client.getEntries({ content_type: 'listener' })
+  .then((response) => {
+    response.items.forEach((listener) => {
+      controller.hears(listener.fields.keywords, listener.fields.events, (bot, message) => {
+        const responseMessages = listener.fields.responseMessages.split('|');
+        const replyMessage = responseMessages[Math.floor(Math.random() * responseMessages.length)];
+        bot.reply(message, replyMessage);
+      });
+    });
+  });
+
 
 controller.hears('help', ['direct_mention', 'direct_message'], (bot, message) => {
   const helpMsg = 'Hey, it\'s me, Puppet Sloth. I\'ve been resurrected as a bot who knows what ' +

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "bluebird": "^3.5.0",
-    "botkit": "^0.2.2",
+    "botkit": "^0.5.2",
+    "contentful": "^3.8.1",
     "superagent": "^3.5.0",
     "winston": "^2.3.1"
   },


### PR DESCRIPTION
Adds `contentful` package to query for Listener entries in the new Slothbot Contentful space, to dynamically add Slothbot listeners and reply messages:

<img width="1242" alt="screen shot 2017-03-20 at 7 09 30 am" src="https://cloud.githubusercontent.com/assets/1236811/24103343/36c33fda-0d3c-11e7-8c7b-daf75d2e7c5e.png">
