### PR TITLE
Check for reply.text

### DIFF
--- a/app/controllers/facebook.js
+++ b/app/controllers/facebook.js
@@ -7,23 +7,6 @@ const gambitChatbot = require('../../lib/gambit/chatbot');
 FB.setAccessToken(process.env.FB_PAGE_ACCESS_TOKEN);
 
 /**
- * @param {object} messageData
- * @param {string} messageText
- */
-function postFacebookMessage(messageData) {
-  logger.debug(`facebook.postFacebookMessage:${JSON.stringify(messageData)}`);
-
-  FB.api('me/messages', 'post', messageData, (res) => {
-    if (!res || res.error) {
-      logger.error(!res ? 'error occurred' : res.error);
-      return;
-    }
-
-    logger.debug(res);
-  });
-}
-
-/**
  * @param {string} recipientId
  * @param {string} messageText
  * @return {object}
@@ -42,6 +25,23 @@ function formatPayload(recipientId, messageText) {
 }
 
 /**
+ * @param {object} messageData
+ * @param {string} messageText
+ */
+function postFacebookMessage(recipientId, messageText) {
+  const data = formatPayload(recipientId, messageText);
+
+  FB.api('me/messages', 'post', data, (res) => {
+    if (!res || res.error) {
+      logger.error(!res ? 'error occurred' : res.error);
+      return;
+    }
+
+    logger.debug(res);
+  });
+}
+
+/**
  * @param {object} event
  */
 module.exports.receivedMessage = function (event) {
@@ -56,14 +56,8 @@ module.exports.receivedMessage = function (event) {
       .then((reply) => {
         if (!reply.text) return true;
 
-        const data = formatPayload(userId, reply.text);
-
-        return postFacebookMessage(data);
+        return postFacebookMessage(userId, reply.text);
       })
-      .catch((err) => {
-        const data = formatPayload(userId, err.message);
-
-        return postFacebookMessage(data);
-      });
+      .catch(err => postFacebookMessage(userId, err.message));
   }
 };

--- a/app/controllers/facebook.js
+++ b/app/controllers/facebook.js
@@ -29,7 +29,7 @@ function postFacebookMessage(messageData) {
  * @return {object}
  */
 function formatPayload(recipientId, messageText) {
-  const messageData = {
+  const data = {
     recipient: {
       id: recipientId,
     },
@@ -38,7 +38,7 @@ function formatPayload(recipientId, messageText) {
     },
   };
 
-  return messageData;
+  return data;
 }
 
 /**
@@ -53,15 +53,17 @@ module.exports.receivedMessage = function (event) {
 
   if (messageText) {
     gambitChatbot.getReply(userId, messageText, 'facebook')
-      .then((gambitReplyText) => {
-        const replyPayload = formatPayload(userId, gambitReplyText);
+      .then((reply) => {
+        if (!reply.text) return true;
 
-        return postFacebookMessage(replyPayload);
+        const data = formatPayload(userId, reply.text);
+
+        return postFacebookMessage(data);
       })
       .catch((err) => {
-        const replyPayload = formatPayload(userId, err.message);
+        const data = formatPayload(userId, err.message);
 
-        return postFacebookMessage(replyPayload);
+        return postFacebookMessage(data);
       });
   }
 };

--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -96,6 +96,11 @@ rtm.on(RTM_EVENTS.MESSAGE, (message) => {
   }
 
   return gambitChatbot.getReply(message.user, message.text, 'slack')
-    .then(reply => rtm.sendMessage(reply, channel))
+    .then((reply) => {
+      // We can sometimes get the silent treatment (e.g. in the Crisis Inbox).
+      if (!reply.text) return true;
+
+      return rtm.sendMessage(reply.text, channel);
+    })
     .catch(err => rtm.sendMessage(err.message, channel));
 });

--- a/lib/gambit/chatbot.js
+++ b/lib/gambit/chatbot.js
@@ -19,7 +19,7 @@ module.exports.getReply = function (userId, text, platform) {
     superagent
       .post(`${uri}chatbot`)
       .send(data)
-      .then(res => resolve(res.body.reply.text))
+      .then(res => resolve(res.body.reply))
       .catch(err => reject(err));
   });
 };


### PR DESCRIPTION
When the Chatbot API response contains an `reply.text` property (e.g. User is in a Support Conversation and shoudln't get automated a response), don't post the empty reply.