### PR TITLE
Action messaging cleanup

### DIFF
--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -87,25 +87,27 @@ module.exports.postCampaignDetailMessage = function (channel, environmentName, c
     });
 };
 
+/**
+ * Posts given messageText to given Slack channel.
+ * @param {string} channel
+ * @param {string} messageText
+ */
 function postMessage(channel, messageText) {
   web.chat.postMessage(channel, messageText);
 }
 
+/**
+ * Posts Slack message for a given Slothie Action.
+ */
 module.exports.postMessageForAction = function (action) {
-  const user = action.data.user;
-  const userId = user._id;
-
-  let text = `User ${userId} cancelled their support request.`;
-  if (user.paused) {
-    let topic = 'Support: Help';
-    if (user.topic === 'topic_support_crisis') {
-      topic = ' Support: Crisis';
-    }
-    text = `*${topic}* flagged message from User ${userId}.`;
+  if (action.type !== 'updateUserPaused') {
+    return;
   }
 
-  postMessage(process.env.SLACK_ALERT_CHANNEL, text);
+  const messageText = slack.parseUpdateUserPausedActionAsText(action);
+  postMessage(process.env.SLACK_ALERT_CHANNEL, messageText);
 };
+
 
 /**
  * Handle message events.

--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -121,19 +121,20 @@ rtm.on(RTM_EVENTS.MESSAGE, (message) => {
 
   logger.debug('slack message received', message);
   const channel = message.channel;
+  const keyword = message.text.toLowerCase().trim();
 
-  if (message.text === 'keywords') {
+  if (keyword === 'keywords') {
     return postCampaignIndexMessage(channel, 'production');
   }
 
-  if (message.text === 'thor') {
+  if (keyword === 'thor') {
     return postCampaignIndexMessage(channel, 'thor');
   }
 
   dashbot.logIncoming(bot, team, message);
   let mediaUrl = null;
   // Hack to upload images (when an image is shared over DM, it's private in Slack).
-  if (message.text === 'photo') {
+  if (keyword === 'photo') {
     // TODO: Allow pasting image URL.
     mediaUrl = 'http://cdn1us.denofgeek.com/sites/denofgeekus/files/dirt-dave-and-gill.jpg';
   }

--- a/app/routes/slack.js
+++ b/app/routes/slack.js
@@ -21,7 +21,7 @@ router.post('/', (req, res) => {
   const channelId = payload.channel.id;
   const data = slack.parseCallbackId(payload.callback_id);
 
-  return controller.sendCampaignDetailMessage(channelId, data.environmentName, data.campaignId);
+  return controller.postCampaignDetailMessage(channelId, data.environmentName, data.campaignId);
 });
 
 module.exports = router;

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -75,7 +75,7 @@ module.exports.parseCampaignAsAttachment = function (environmentName, campaign, 
       },
     ],
   };
-  logger.debug(attachment);
+  logger.trace('parseCampaignAsAttachment', attachment);
 
   return attachment;
 };
@@ -117,7 +117,7 @@ module.exports.parseCampaignMessageAsAttachment = function (messageType, message
   if (!attachment.text) {
     attachment.text = 'N/A';
   }
-  logger.debug(attachment);
+  logger.trace('parseCampaignMessageAsAttachment', attachment);
 
   return attachment;
 };

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -121,3 +121,30 @@ module.exports.parseCampaignMessageAsAttachment = function (messageType, message
 
   return attachment;
 };
+
+/**
+ * Returns text to display for a given Action with type === 'updateUserPaused'.
+ * @param {object} action
+ * @return {string}
+ */
+module.exports.parseUpdateUserPausedActionAsText = function (action) {
+  const user = action.data.user;
+  const userId = `User ${user._id}`;
+
+  if (!user.paused) {
+    return `${userId} cancelled their support request.`;
+  }
+
+  if (user.topic === 'support_question') {
+    return `*Support - Question*: New message from ${userId}.`;
+  }
+
+  let topicName = 'Support - Warning';
+  if (user.topic === 'support_crisis') {
+    topicName = ' Support - Crisis';
+  }
+
+  const text = `*${topicName}*: Flagged message from ${userId}.`;
+
+  return text;
+};


### PR DESCRIPTION
* Adds a `parseUpdateUserPausedActionAsText` function to parse `updateUserPaused` actions.
* Fixes Dashbot incoming/outgoing messages
* Trims Slack message text to look for Slack specific keywords (`keywords`, `thor`, `photo`)