### PR TITLE
Updating to Node v6.11.1 to fix DoS vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.7.3",
   "description": "lets get causey",
   "engines": {
-    "node": ">=6.10.x"
+    "node": ">=6.11.1"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Heroku sent an email indicating that all NodeJS applications that aren't running one of the following NodeJS versions should be updated due to DoS attack vulnerabilities. 4.8.4, 6.11.1, 7.10.1, or 8.1.4. This app had >=6.10.x listed as the engine, and this PR updates it to >=6.11.1.